### PR TITLE
Enforce governance validation before sending logs

### DIFF
--- a/LoggingStandards/Classes/Logging.cs
+++ b/LoggingStandards/Classes/Logging.cs
@@ -185,7 +185,7 @@ namespace CerbiClientLogging.Implementations
                 EncryptInternalSecrets(metadata);
             }
 
-            if (!_options.ValidateLog(_options.QueueType, metadata))
+            if (!_options.ValidateLog(_options.GovernanceProfileName, metadata))
             {
                 Console.WriteLine("[CerbiStream] Governance validation failed; dropping log.");
                 return Task.FromResult(false);
@@ -236,6 +236,12 @@ namespace CerbiClientLogging.Implementations
                 EncryptInternalSecrets(metadata);
             }
 
+            if (!_options.ValidateLog(_options.GovernanceProfileName, metadata))
+            {
+                Console.WriteLine("[CerbiStream] Governance validation failed; dropping log.");
+                return Task.FromResult(false);
+            }
+
             if (_governanceValidator != null)
             {
                 _governanceValidator.ValidateInPlace(metadata);
@@ -269,6 +275,12 @@ namespace CerbiClientLogging.Implementations
             {
                 EnrichMetadata(metadata);
                 EncryptInternalSecrets(metadata);
+            }
+
+            if (!_options.ValidateLog(_options.GovernanceProfileName, metadata))
+            {
+                Console.WriteLine("[CerbiStream] Governance validation failed; dropping log.");
+                return Task.FromResult(false);
             }
 
             var entry = new

--- a/LoggingStandards/Configuration/CerbiStreamOptions.cs
+++ b/LoggingStandards/Configuration/CerbiStreamOptions.cs
@@ -317,6 +317,7 @@ namespace CerbiStream.Logging.Configuration
         public CerbiStreamOptions WithGovernanceValidator(Func<string, Dictionary<string, object>, bool> validator)
         {
             GovernanceValidator = validator;
+            EnableGovernanceChecks = true;
             return this;
         }
 
@@ -496,8 +497,15 @@ namespace CerbiStream.Logging.Configuration
                 .WithGovernanceChecks(false);
         }
 
-        public bool ValidateLog(string profileName, Dictionary<string, object> logData) =>
-            !EnableGovernanceChecks || (GovernanceValidator?.Invoke(profileName, logData) ?? true);
+        public bool ValidateLog(string profileName, Dictionary<string, object> logData)
+        {
+            if (GovernanceValidator is not null)
+            {
+                return GovernanceValidator(profileName, logData);
+            }
+
+            return true; // No validator configured; nothing to enforce.
+        }
 
         public bool ShouldSkipQueueSend() => DisableQueueSending;
 


### PR DESCRIPTION
## Summary
- ensure custom governance validators enable governance checks and run when provided
- validate logging, application, and performance payloads against the configured governance profile before sending

## Testing
- not run (dotnet SDK unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921161176d4832d865b03c77a91efa8)

## Summary by Sourcery

Enforce governance validation using configured profiles before sending any logs.

Bug Fixes:
- Ensure governance validation is applied consistently to application, event, and performance logs based on the configured governance profile.
- Automatically enable governance checks when a custom governance validator is configured so validations are not silently skipped.

Enhancements:
- Simplify governance validation behavior so logs are always validated when a governance validator is present and are allowed when no validator is configured.