### PR TITLE
Return pooled dictionaries after JSON governance validation

### DIFF
--- a/LoggingStandards/Classes/Governance/GovernanceRuntimeAdapter.cs
+++ b/LoggingStandards/Classes/Governance/GovernanceRuntimeAdapter.cs
@@ -135,8 +135,18 @@ public sealed class GovernanceRuntimeAdapter
  }
  }
 
- public void ValidateAndRedactInPlace(JsonElement json)
- => ValidateAndRedactInPlace(ToDictionary(json));
+    public void ValidateAndRedactInPlace(JsonElement json)
+    {
+        var dict = ToDictionary(json);
+        try
+        {
+            ValidateAndRedactInPlace(dict);
+        }
+        finally
+        {
+            ReturnDictionaryToPool(dict);
+        }
+    }
 
  private static bool IsRelaxed(IDictionary<string, object> data)
  => data.TryGetValue("GovernanceRelaxed", out var v) && v is true;


### PR DESCRIPTION
## Summary
- ensure the JsonElement overload returns rented dictionaries to the pool when validating and redacting
- add a governance adapter unit test to verify pooled dictionaries are restored after JsonElement processing

## Testing
- not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921161176d4832d865b03c77a91efa8)

## Summary by Sourcery

Ensure JSON governance validation with JsonElement returns pooled dictionaries to avoid resource leaks and add coverage for this behavior.

Bug Fixes:
- Return dictionaries rented from the pool after JsonElement-based ValidateAndRedactInPlace to prevent pool depletion.

Tests:
- Add a governance adapter unit test to verify pooled dictionaries are restored after JsonElement processing.