### PR TITLE
Add .NET 9 targeting for CerbiStream library

### DIFF
--- a/LoggingStandards/CerbiStream.csproj
+++ b/LoggingStandards/CerbiStream.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <UseWindowsForms>false</UseWindowsForms>

--- a/LoggingStandards/README-CerbiStreamDeveloperQuickStart.md
+++ b/LoggingStandards/README-CerbiStreamDeveloperQuickStart.md
@@ -3,6 +3,8 @@
 
 > This guide covers how to configure optional advanced features for **CerbiStream** to maximize reliability, observability, and compliance.
 
+**Target frameworks:** .NET 8.0 (LTS) and .NET 9.0
+
 ---
 
 ## 1. Retry Policies (Queue Failures)

--- a/LoggingStandards/README-CerbiStream–AdvancedSetup&BestPractices.md
+++ b/LoggingStandards/README-CerbiStream–AdvancedSetup&BestPractices.md
@@ -3,6 +3,8 @@
 
 > This guide covers how to configure optional advanced features for **CerbiStream** to maximize reliability, observability, and compliance.
 
+**Target frameworks:** .NET 8.0 (LTS) and .NET 9.0
+
 ---
 
 ## 1. Retry Policies (Queue Failures)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 CerbiStream is a **governance and safety layer** for .NET logging. It validates, redacts, tags, and optionally encrypts logs **before they reach any sink**.
 
+**Target frameworks:** .NET 8.0 (LTS) and .NET 9.0
+
 Keep your existing stack:
 
 - `Microsoft.Extensions.Logging` (MEL)


### PR DESCRIPTION
## Summary
- multi-target the CerbiStream library for .NET 8.0 and .NET 9.0
- document the supported target frameworks in the root and package READMEs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fcb23a46c832d92cc4437c5b9682f)

## Summary by Sourcery

Multi-target the CerbiStream library for both .NET 8.0 and .NET 9.0 and document the supported frameworks in the README files.

Enhancements:
- Update CerbiStream project targeting to include .NET 9.0 alongside .NET 8.0.

Documentation:
- Document the supported .NET target frameworks (.NET 8.0 LTS and .NET 9.0) in the root and CerbiStream developer quickstart READMEs.