### PR TITLE
Add net8/net9 multi-targeting and update docs

### DIFF
--- a/BenchmarkSuite1/BenchmarkSuite1.csproj
+++ b/BenchmarkSuite1/BenchmarkSuite1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <!-- Change to a class library so external runners can discover and run benchmarks without a Main() -->
     <OutputType>Exe</OutputType>
     <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>

--- a/CerbiStream--UnitTests/UnitTests.csproj
+++ b/CerbiStream--UnitTests/UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/LoggingStandards/README-CerbiStreamDeveloperQuickStart.md
+++ b/LoggingStandards/README-CerbiStreamDeveloperQuickStart.md
@@ -3,7 +3,7 @@
 
 > This guide covers how to configure optional advanced features for **CerbiStream** to maximize reliability, observability, and compliance.
 
-**Target frameworks:** .NET 8.0 (LTS) and .NET 9.0
+**Targets .NET 8.0 and .NET 9.0.** .NET 10+ is supported via compatibility (computed frameworks on NuGet).
 
 ---
 

--- a/LoggingStandards/README-CerbiStream–AdvancedSetup&BestPractices.md
+++ b/LoggingStandards/README-CerbiStream–AdvancedSetup&BestPractices.md
@@ -3,7 +3,7 @@
 
 > This guide covers how to configure optional advanced features for **CerbiStream** to maximize reliability, observability, and compliance.
 
-**Target frameworks:** .NET 8.0 (LTS) and .NET 9.0
+**Targets .NET 8.0 and .NET 9.0.** .NET 10+ is supported via compatibility (computed frameworks on NuGet).
 
 ---
 

--- a/MicroHarness/MicroHarness.csproj
+++ b/MicroHarness/MicroHarness.csproj
@@ -2,7 +2,7 @@
 
  <PropertyGroup>
  <OutputType>Exe</OutputType>
- <TargetFramework>net8.0</TargetFramework>
+ <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
  <ImplicitUsings>enable</ImplicitUsings>
  </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 CerbiStream is a **governance and safety layer** for .NET logging. It validates, redacts, tags, and optionally encrypts logs **before they reach any sink**.
 
-**Target frameworks:** .NET 8.0 (LTS) and .NET 9.0
+**Targets .NET 8.0 and .NET 9.0.** .NET 10+ is supported via compatibility (computed frameworks on NuGet).
 
 Keep your existing stack:
 

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 <!--<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- update project files to target both .NET 8.0 and .NET 9.0
- refresh README content to note .NET 8/9 targets and .NET 10+ compatibility

## Testing
- dotnet restore CerbiStream.sln
- dotnet build CerbiStream.sln

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930598ed994832dafdf00dd59d5ab61)

## Summary by Sourcery

Update project multi-targeting to support both .NET 8.0 and .NET 9.0 and refresh documentation to reflect current framework support and forward compatibility.

Enhancements:
- Multi-target application, benchmarks, and test projects for both .NET 8.0 and .NET 9.0.

Documentation:
- Update README files to describe .NET 8.0 and .NET 9.0 targets and clarify .NET 10+ compatibility via computed frameworks on NuGet.