### PR TITLE
Align governance runtime compatibility across TFMs

### DIFF
--- a/CerbiStream--UnitTests/CerbiStreamGovernanceTests.cs
+++ b/CerbiStream--UnitTests/CerbiStreamGovernanceTests.cs
@@ -1,19 +1,23 @@
-﻿using System;
+extern alias GovernanceCore;
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using Cerbi.Governance;
+using CerbiGovernanceModel = GovernanceCore::Cerbi.Governance.CerbiGovernance;
+using LogProfile = GovernanceCore::Cerbi.Governance.LogProfile;
 using Xunit;
 
 namespace CerbiStream.Tests
 {
     public class CerbiStreamGovernanceTests
     {
-        private static CerbiGovernance Load(string path)
+        private static CerbiGovernanceModel Load(string path)
         {
             if (!File.Exists(path))
             {
-                return new CerbiGovernance
+                return new CerbiGovernanceModel
                 {
                     LoggingProfiles = new Dictionary<string, LogProfile>(StringComparer.OrdinalIgnoreCase)
                 };
@@ -24,23 +28,23 @@ namespace CerbiStream.Tests
                 var json = File.ReadAllText(path);
                 if (string.IsNullOrWhiteSpace(json))
                 {
-                    return new CerbiGovernance
+                    return new CerbiGovernanceModel
                     {
                         LoggingProfiles = new Dictionary<string, LogProfile>(StringComparer.OrdinalIgnoreCase)
                     };
                 }
 
-                return JsonSerializer.Deserialize<CerbiGovernance>(json, new JsonSerializerOptions
+                return JsonSerializer.Deserialize<CerbiGovernanceModel>(json, new JsonSerializerOptions
                 {
                     PropertyNameCaseInsensitive = true
-                }) ?? new CerbiGovernance
+                }) ?? new CerbiGovernanceModel
                 {
                     LoggingProfiles = new Dictionary<string, LogProfile>(StringComparer.OrdinalIgnoreCase)
                 };
             }
             catch
             {
-                return new CerbiGovernance
+                return new CerbiGovernanceModel
                 {
                     LoggingProfiles = new Dictionary<string, LogProfile>(StringComparer.OrdinalIgnoreCase)
                 };
@@ -66,7 +70,7 @@ namespace CerbiStream.Tests
         [Fact]
         public void LoadGovernance_FileIsValidJson_LoadsProfiles()
         {
-            var profile = new CerbiGovernance
+            var profile = new CerbiGovernanceModel
             {
                 LoggingProfiles = new Dictionary<string, LogProfile>
                 {

--- a/CerbiStream--UnitTests/GovernanceRuntimeAdapterTests.cs
+++ b/CerbiStream--UnitTests/GovernanceRuntimeAdapterTests.cs
@@ -1,3 +1,5 @@
+extern alias GovernanceCore;
+
 using Cerbi.Governance;
 using CerbiStream.GovernanceRuntime.Governance;
 using System;
@@ -10,6 +12,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit;
+using GovernanceViolation = GovernanceCore::Cerbi.Governance.GovernanceViolation;
 
 namespace CerbiStream.Tests
 {

--- a/CerbiStream--UnitTests/GovernanceRuntimeTests.cs
+++ b/CerbiStream--UnitTests/GovernanceRuntimeTests.cs
@@ -1,10 +1,13 @@
-﻿using CerbiStream.GovernanceRuntime.Governance;
+extern alias GovernanceCore;
+
+using CerbiStream.GovernanceRuntime.Governance;
 using CerbiStream.Observability;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Linq;
 using Cerbi.Governance;
 using Xunit;
+using GovernanceViolation = GovernanceCore::Cerbi.Governance.GovernanceViolation;
 
 namespace CerbiStream.Tests;
 

--- a/CerbiStream--UnitTests/UnitTests.csproj
+++ b/CerbiStream--UnitTests/UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -20,6 +20,10 @@
     <PackageReference Include="Castle.Core" Version="5.1.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="Cerbi.Governance.Core" Version="1.0.15">
+      <Aliases>GovernanceCore</Aliases>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/LoggingStandards/CerbiStream.csproj
+++ b/LoggingStandards/CerbiStream.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <UseWindowsForms>false</UseWindowsForms>
@@ -24,7 +24,7 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>1.1.20</Version>
+    <Version>1.1.21</Version>
 
     <!-- NuGet metadata -->
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -49,8 +49,10 @@
     <PackageReference Include="Azure.Storage.Common" Version="12.24.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.23.0" />
     <PackageReference Include="cerberus-logger-interface" Version="1.0.26" />
-    <PackageReference Include="Cerbi.Governance.Core" Version="1.0.15" />
-    <PackageReference Include="Cerbi.Governance.Runtime" Version="1.1.1" />
+    <PackageReference Include="Cerbi.Governance.Core" Version="1.0.15">
+      <Aliases>GovernanceCore</Aliases>
+    </PackageReference>
+    <PackageReference Include="Cerbi.Governance.Runtime" Version="1.1.7" />
     <PackageReference Include="Datadog.Trace" Version="3.25.0" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="4.4.0" />
     <PackageReference Include="Google.Cloud.PubSub.V1" Version="3.27.0" />

--- a/LoggingStandards/Classes/Governance/GovernanceRuntimeAdapter.cs
+++ b/LoggingStandards/Classes/Governance/GovernanceRuntimeAdapter.cs
@@ -1,4 +1,7 @@
-﻿using Cerbi.Governance; // RuntimeGovernanceValidator, IRuntimeGovernanceSource, FileGovernanceSource
+extern alias GovernanceCore;
+
+using Cerbi.Governance; // RuntimeGovernanceValidator, IRuntimeGovernanceSource, FileGovernanceSource
+using GovernanceViolation = GovernanceCore::Cerbi.Governance.GovernanceViolation;
 using CerbiStream.Observability;
 using System;
 using System.Collections;
@@ -49,11 +52,12 @@ public sealed class GovernanceRuntimeAdapter
 
  IRuntimeGovernanceSource source = new FileGovernanceSource(_configPath);
 
- // ctor: (isEnabled, profileName, source)
- _validator = new RuntimeGovernanceValidator(
- isEnabled: () => true,
- profileName: _profileName,
- source: source);
+    // ctor: (isEnabled, profileName, source, plugins)
+    _validator = new RuntimeGovernanceValidator(
+        isEnabled: () => true,
+        profileName: _profileName,
+        source: source,
+        plugins: Array.Empty<IRuntimeGovernancePlugin>());
 
  TryInitWatcher();
  }

--- a/README.md
+++ b/README.md
@@ -190,6 +190,16 @@ logger.LogInformation("User signup", new
 
 CerbiStream will **redact** disallowed/forbidden fields and **add governance tags** before any sink sees the event.
 
+### Governance Runtime & Analyzer Compatibility
+
+| TFM      | CerbiStream package | Cerbi.Governance.Runtime | CerbiStream.GovernanceAnalyzer |
+|----------|---------------------|--------------------------|--------------------------------|
+| net8.0   | 1.1.21              | 1.1.7                    | 1.1.21                         |
+| net9.0   | 1.1.21              | 1.1.7                    | 1.1.21                         |
+| net10.0  | 1.1.21              | 1.1.7                    | 1.5.48                         |
+
+`AddCerbiGovernanceRuntime` is compiled against the current Cerbi.Governance.Runtime API. Use the versions above to avoid `Method not found: RuntimeGovernanceValidator..ctor` when pairing governed logging with runtime validation.
+
 ---
 
 ## 🔍 Governance Example: Before vs After


### PR DESCRIPTION
## Summary
- multi-target CerbiStream packages for net8/net9/net10 and update Cerbi.Governance.Runtime to the current API
- align GovernanceRuntimeAdapter with the new validator constructor and resolve CerbiGovernance type collisions using aliases
- document runtime/analyzer version matrix for AddCerbiGovernanceRuntime consumers

## Testing
- dotnet test
- dotnet test CerbiStream--UnitTests/UnitTests.csproj -f net9.0
- dotnet test CerbiStream--UnitTests/UnitTests.csproj -f net10.0


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951f0d57400832da72ed347b9d3a2e5)

## Summary by Sourcery

Align CerbiStream governance runtime integration with the updated Cerbi.Governance.Runtime API and document version compatibility across target frameworks.

Enhancements:
- Update GovernanceRuntimeAdapter to use the new RuntimeGovernanceValidator constructor signature with plugin support.
- Introduce extern aliases and type aliases to disambiguate Cerbi governance types when integrating with the core governance library.

Documentation:
- Document the compatibility matrix between CerbiStream TFMs, Cerbi.Governance.Runtime, and CerbiStream.GovernanceAnalyzer, including guidance to avoid runtime constructor missing-method errors.

Tests:
- Adjust governance-related unit tests to use the aliased governance core types and validate behavior against the updated runtime integration.