### PR TITLE
Address CVE-2021-26701 via System.Text.Encodings.Web update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
+## [1.1.22] - 2026-01-01
+### Security
+- Added an explicit reference to `System.Text.Encodings.Web` 8.0.0 to ensure builds consume a version that addresses CVE-2021-26701.
+
 ## [1.1.20] -2025-10-30
 ### Changed
 - Pinned build to .NET9 SDK via `global.json` (roll-forward latestFeature; allowPrerelease=true). Planned post-GA bump to `10.0.100`.

--- a/LoggingStandards/CerbiStream.csproj
+++ b/LoggingStandards/CerbiStream.csproj
@@ -24,7 +24,7 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>1.1.21</Version>
+    <Version>1.1.22</Version>
 
     <!-- NuGet metadata -->
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -70,6 +70,7 @@
     <PackageReference Include="Polly" Version="8.6.3" />
     <PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.8" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
     <PackageReference Include="System.Diagnostics.EventLog" Version="9.0.8" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.8" />

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -2,8 +2,5 @@
 
 Use this file to track changes between releases.
 
-Template
-- Added:
-- Changed:
-- Fixed:
-- Security:
+## 1.1.22 - 2026-01-01
+- Security: Added an explicit dependency on `System.Text.Encodings.Web` 8.0.0 to remediate CVE-2021-26701 across downstream consumers.


### PR DESCRIPTION
## Summary
- bump CerbiStream package version to 1.1.22
- add an explicit System.Text.Encodings.Web 8.0.0 reference to mitigate CVE-2021-26701
- document the security fix in the changelog and release notes

## Testing
- not run (dotnet SDK unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955c2d23254832d801de96d3d81dc6b)

## Summary by Sourcery

Update CerbiStream package to version 1.1.22 and explicitly depend on System.Text.Encodings.Web 8.0.0 to address a known security vulnerability, documenting the change in project release notes.

Build:
- Bump CerbiStream package version to 1.1.22 and add an explicit dependency on System.Text.Encodings.Web 8.0.0 for secure builds.

Documentation:
- Document the 1.1.22 security release and the explicit System.Text.Encodings.Web 8.0.0 dependency in the changelog and release notes.