### PR TITLE
Emit governance evidence metadata from CerbiStream

### DIFF
--- a/CerbiStream--UnitTests/GovernanceRuntimeAdapterTests.cs
+++ b/CerbiStream--UnitTests/GovernanceRuntimeAdapterTests.cs
@@ -234,5 +234,94 @@ namespace CerbiStream.Tests
             var finalCount = pool.Count;
             Assert.Equal(initialCount, finalCount);
         }
+
+
+        [Fact(DisplayName = "ValidateAndRedactInPlace - No violations stamps allowed none")]
+        public void ValidateAndRedactInPlace_NoViolations_StampsAllowedNone()
+        {
+            var temp = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(temp, "{\"Version\":\"1.2\",\"LoggingProfiles\":{\"default\":{\"GovernanceProfileVersion\":\"2026.07\",\"DisallowedFields\":[],\"FieldSeverities\":{}}}}");
+                var adapter = new GovernanceRuntimeAdapter("default", temp);
+                var data = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase) { ["message"] = "ok" };
+
+                adapter.ValidateAndRedactInPlace(data);
+
+                Assert.Equal("allowed", data["GovernanceDecision"]);
+                Assert.Equal("none", data["EnforcementAction"]);
+                Assert.False(string.IsNullOrWhiteSpace(data["GovernanceProfileHash"].ToString()));
+            }
+            finally { File.Delete(temp); }
+        }
+
+        [Fact(DisplayName = "ValidateAndRedactInPlace - Forbidden field redacted stamps redacted redact")]
+        public void ValidateAndRedactInPlace_ForbiddenField_StampsRedactedRedact()
+        {
+            var temp = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(temp, "{\"Version\":\"1.2\",\"LoggingProfiles\":{\"default\":{\"DisallowedFields\":[\"secret\"],\"FieldSeverities\":{}}}}");
+                var adapter = new GovernanceRuntimeAdapter("default", temp);
+                var data = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase) { ["secret"] = "value" };
+
+                adapter.ValidateAndRedactInPlace(data);
+
+                Assert.Equal("***REDACTED***", data["secret"]);
+                Assert.Equal("redacted", data["GovernanceDecision"]);
+                Assert.Equal("redact", data["EnforcementAction"]);
+            }
+            finally { File.Delete(temp); }
+        }
+
+        [Fact(DisplayName = "ValidateAndRedactInPlace - Relaxed mode stamps relaxed allow")]
+        public void ValidateAndRedactInPlace_Relaxed_StampsRelaxedAllow()
+        {
+            var temp = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(temp, "{\"Version\":\"1.2\",\"LoggingProfiles\":{\"default\":{}}}");
+                var adapter = new GovernanceRuntimeAdapter("default", temp);
+                var data = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase) { ["GovernanceRelaxed"] = true, ["secret"] = "value" };
+
+                adapter.ValidateAndRedactInPlace(data);
+
+                Assert.Equal("relaxed", data["GovernanceDecision"]);
+                Assert.Equal("allow", data["EnforcementAction"]);
+            }
+            finally { File.Delete(temp); }
+        }
+
+        [Fact(DisplayName = "GetPolicyEvidence - Missing config returns empty evidence")]
+        public void GetPolicyEvidence_MissingConfig_ReturnsEmpty()
+        {
+            var missing = Path.Combine(Path.GetTempPath(), $"missing_{Guid.NewGuid():N}.json");
+            var adapter = new GovernanceRuntimeAdapter("default", missing);
+
+            var evidence = adapter.GetPolicyEvidence();
+
+            Assert.True(evidence.IsEmpty);
+        }
+
+        [Fact(DisplayName = "GetPolicyEvidence - Hash stable for identical active profile config")]
+        public void GetPolicyEvidence_StableHash_ForIdenticalConfig()
+        {
+            var temp1 = Path.GetTempFileName();
+            var temp2 = Path.GetTempFileName();
+            try
+            {
+                var json = "{\"Version\":\"1.2\",\"LoggingProfiles\":{\"default\":{\"DisallowedFields\":[\"secret\"],\"FieldSeverities\":{\"ssn\":\"Forbidden\"}}}}";
+                File.WriteAllText(temp1, json);
+                File.WriteAllText(temp2, json);
+
+                var hash1 = new GovernanceRuntimeAdapter("default", temp1).GetPolicyEvidence().ProfileHash;
+                var hash2 = new GovernanceRuntimeAdapter("default", temp2).GetPolicyEvidence().ProfileHash;
+
+                Assert.False(string.IsNullOrWhiteSpace(hash1));
+                Assert.Equal(hash1, hash2);
+            }
+            finally { File.Delete(temp1); File.Delete(temp2); }
+        }
+
     }
 }

--- a/CerbiStream--UnitTests/ScoringEventTransformerTests.cs
+++ b/CerbiStream--UnitTests/ScoringEventTransformerTests.cs
@@ -202,4 +202,39 @@ public class ScoringEventTransformerTests
         // Assert - Data TenantId is used
         Assert.Equal("data-tenant", result.TenantId);
     }
+
+    [Fact]
+    public void Transform_PopulatesGovernanceEvidenceMetadata_WhenStampedOnLogEntry()
+    {
+        var options = new CerbiStreamOptions().WithTenantId("test-tenant");
+        var logEntry = new Dictionary<string, object>
+        {
+            ["Message"] = "Test",
+            ["GovernanceProfileId"] = "default",
+            ["GovernanceProfileVersion"] = "2026.07",
+            ["GovernanceProfileHash"] = "abc123",
+            ["GovernanceDecision"] = "allowed",
+            ["EnforcementAction"] = "none"
+        };
+
+        var result = ScoringEventTransformer.Transform(logEntry, "log-evidence", options);
+
+        Assert.Equal("abc123", result.GetType().GetProperty("GovernanceProfileHash")?.GetValue(result)?.ToString());
+        Assert.Equal("allowed", result.GetType().GetProperty("GovernanceDecision")?.GetValue(result)?.ToString());
+        Assert.Equal("none", result.GetType().GetProperty("EnforcementAction")?.GetValue(result)?.ToString());
+    }
+
+    [Fact]
+    public void Transform_MissingConfigAdapter_DoesNotThrowAndStillEmitsEvent()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"missing_{Guid.NewGuid():N}.json");
+        var adapter = new GovernanceRuntimeAdapter("default", missing);
+        var options = new CerbiStreamOptions().WithTenantId("test-tenant");
+
+        var result = ScoringEventTransformer.Transform(new { Message = "Test" }, "log-missing-config", options, null, adapter);
+
+        Assert.Equal("log-missing-config", result.LogId);
+        Assert.Equal("test-tenant", result.TenantId);
+    }
+
 }

--- a/LoggingStandards/CerbiStream.csproj
+++ b/LoggingStandards/CerbiStream.csproj
@@ -53,6 +53,7 @@
       <Aliases>GovernanceCore</Aliases>
     </PackageReference>
     <PackageReference Include="Cerbi.Governance.Runtime" Version="1.1.7" />
+    <PackageReference Include="CerbiShield.Contracts" Version="1.2.0-preview.1" />
     <PackageReference Include="Datadog.Trace" Version="3.25.0" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="4.4.0" />
     <PackageReference Include="Google.Cloud.PubSub.V1" Version="3.27.0" />

--- a/LoggingStandards/Classes/Governance/GovernanceRuntimeAdapter.cs
+++ b/LoggingStandards/Classes/Governance/GovernanceRuntimeAdapter.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading;
 
@@ -39,6 +40,11 @@ public sealed class GovernanceRuntimeAdapter
  private string? _cachedTenantId;
  private DateTime _tenantIdLoadedUtc;
  private readonly object _tenantIdLock = new();
+
+ // Cache for policy evidence metadata from config file
+ private GovernancePolicyEvidence _cachedPolicyEvidence = GovernancePolicyEvidence.Empty;
+ private DateTime _policyEvidenceLoadedUtc;
+ private readonly object _policyEvidenceLock = new();
 
  // File watcher to avoid checking file timestamp on every validation
  private volatile int _policyStale;
@@ -105,6 +111,41 @@ public sealed class GovernanceRuntimeAdapter
   }
  }
 
+
+ /// <summary>
+ /// Gets stable policy evidence metadata for the active governance profile.
+ /// Hashing uses the canonical active profile JSON when available, otherwise the full config JSON.
+ /// Returns empty values if the config is missing or malformed.
+ /// </summary>
+ public GovernancePolicyEvidence GetPolicyEvidence()
+ {
+  try
+  {
+   if (!File.Exists(_configPath))
+    return GovernancePolicyEvidence.Empty;
+
+   var lastWrite = File.GetLastWriteTimeUtc(_configPath);
+   if (_policyEvidenceLoadedUtc >= lastWrite && !_cachedPolicyEvidence.IsEmpty)
+    return _cachedPolicyEvidence;
+
+   lock (_policyEvidenceLock)
+   {
+    lastWrite = File.GetLastWriteTimeUtc(_configPath);
+    if (_policyEvidenceLoadedUtc < lastWrite || _cachedPolicyEvidence.IsEmpty)
+    {
+     _cachedPolicyEvidence = ParsePolicyEvidence(_configPath, _profileName);
+     _policyEvidenceLoadedUtc = lastWrite;
+    }
+   }
+
+   return _cachedPolicyEvidence;
+  }
+  catch
+  {
+   return GovernancePolicyEvidence.Empty;
+  }
+ }
+
  private static string? ParseTenantIdFromConfig(string path)
  {
   try
@@ -125,6 +166,146 @@ public sealed class GovernanceRuntimeAdapter
   catch
   {
    return null;
+  }
+ }
+
+
+ private void StampPolicyEvidence(IDictionary<string, object> data)
+ {
+  var evidence = GetPolicyEvidence();
+  if (!string.IsNullOrWhiteSpace(evidence.ProfileId))
+   data["GovernanceProfileId"] = evidence.ProfileId!;
+  if (!string.IsNullOrWhiteSpace(evidence.ProfileVersion))
+   data["GovernanceProfileVersion"] = evidence.ProfileVersion!;
+  if (!string.IsNullOrWhiteSpace(evidence.ProfileHash))
+   data["GovernanceProfileHash"] = evidence.ProfileHash!;
+ }
+
+ private static void StampGovernanceDecision(IDictionary<string, object> data, long redactedCount)
+ {
+  if (IsRelaxed(data))
+  {
+   data["GovernanceDecision"] = "relaxed";
+   data["EnforcementAction"] = "allow";
+   return;
+  }
+
+  if (redactedCount > 0)
+  {
+   data["GovernanceDecision"] = "redacted";
+   data["EnforcementAction"] = "redact";
+   return;
+  }
+
+  var hasViolations = data.TryGetValue("GovernanceViolations", out var raw) && HasAnyViolation(raw);
+  data["GovernanceDecision"] = hasViolations ? "warned" : "allowed";
+  data["EnforcementAction"] = hasViolations ? "warn" : "none";
+ }
+
+ private static bool HasAnyViolation(object? raw)
+ {
+  if (raw is null) return false;
+  if (raw is string s)
+  {
+   if (string.IsNullOrWhiteSpace(s)) return false;
+   try
+   {
+    using var doc = JsonDocument.Parse(s);
+    return doc.RootElement.ValueKind == JsonValueKind.Array && doc.RootElement.GetArrayLength() > 0;
+   }
+   catch { return false; }
+  }
+  if (raw is JsonElement el)
+  {
+   return el.ValueKind == JsonValueKind.Array && el.GetArrayLength() > 0;
+  }
+  if (raw is IEnumerable enumerable)
+  {
+   foreach (var _ in enumerable) return true;
+  }
+  return false;
+ }
+
+ private static GovernancePolicyEvidence ParsePolicyEvidence(string path, string profileName)
+ {
+  try
+  {
+   using var fs = File.OpenRead(path);
+   using var doc = JsonDocument.Parse(fs);
+   var root = doc.RootElement;
+   var profile = TryGetActiveProfile(root, profileName, out var profileNameFromConfig) ? profileNameFromConfig.Profile : default;
+   var hashElement = profile.ValueKind == JsonValueKind.Object ? profile : root;
+   var hash = ComputeCanonicalJsonHash(hashElement);
+   var id = ExtractStringProperty(profile, "GovernanceProfileId") ?? ExtractStringProperty(profile, "ProfileId") ?? profileNameFromConfig.Name;
+   var version = ExtractStringProperty(profile, "GovernanceProfileVersion") ?? ExtractStringProperty(profile, "Version") ?? ExtractStringProperty(root, "Version");
+   return new GovernancePolicyEvidence(id, version, hash);
+  }
+  catch
+  {
+   return GovernancePolicyEvidence.Empty;
+  }
+ }
+
+ private static bool TryGetActiveProfile(JsonElement root, string profileName, out (string? Name, JsonElement Profile) result)
+ {
+  result = default;
+  if (!TryGetPropertyCI(root, "LoggingProfiles", out var profilesEl) || profilesEl.ValueKind != JsonValueKind.Object)
+   return false;
+  JsonProperty? first = null;
+  foreach (var p in profilesEl.EnumerateObject())
+  {
+   first ??= p;
+   if (string.Equals(p.Name, profileName, StringComparison.OrdinalIgnoreCase))
+   {
+    result = (p.Name, p.Value);
+    return true;
+   }
+  }
+  if (first.HasValue)
+  {
+   result = (first.Value.Name, first.Value.Value);
+   return true;
+  }
+  return false;
+ }
+
+ private static string? ExtractStringProperty(JsonElement element, string name)
+ {
+  if (element.ValueKind != JsonValueKind.Object || !TryGetPropertyCI(element, name, out var value)) return null;
+  return value.ValueKind == JsonValueKind.String ? value.GetString() : value.ToString();
+ }
+
+ private static string ComputeCanonicalJsonHash(JsonElement element)
+ {
+  using var stream = new MemoryStream();
+  using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = false }))
+  {
+   WriteCanonicalJson(writer, element);
+  }
+  return Convert.ToHexString(SHA256.HashData(stream.ToArray())).ToLowerInvariant();
+ }
+
+ private static void WriteCanonicalJson(Utf8JsonWriter writer, JsonElement element)
+ {
+  switch (element.ValueKind)
+  {
+   case JsonValueKind.Object:
+    writer.WriteStartObject();
+    foreach (var prop in element.EnumerateObject().OrderBy(p => p.Name, StringComparer.Ordinal))
+    {
+     writer.WritePropertyName(prop.Name);
+     WriteCanonicalJson(writer, prop.Value);
+    }
+    writer.WriteEndObject();
+    break;
+   case JsonValueKind.Array:
+    writer.WriteStartArray();
+    foreach (var item in element.EnumerateArray()) WriteCanonicalJson(writer, item);
+    writer.WriteEndArray();
+    break;
+   default:
+    element.WriteTo(writer);
+    break;
   }
  }
 
@@ -160,6 +341,8 @@ public sealed class GovernanceRuntimeAdapter
  if (IsRelaxed(data))
  {
  data["GovernanceRelaxed"] = true;
+ StampPolicyEvidence(data);
+ StampGovernanceDecision(data, redactedCount: 0);
  return;
  }
 
@@ -200,6 +383,9 @@ public sealed class GovernanceRuntimeAdapter
  if (RedactIfPresentAndCount(working, field)) redacted++;
  }
  if (redacted >0) Metrics.IncrementRedactions(redacted);
+
+ StampPolicyEvidence(working);
+ StampGovernanceDecision(working, redacted);
 
  //4) Copy changes back into original IDictionary if a different instance was created
  if (!ReferenceEquals(working, data))
@@ -863,5 +1049,10 @@ public sealed class GovernanceRuntimeAdapter
   }
   data["GovernanceViolations"] = violations;
   }
+ }
+ public sealed record GovernancePolicyEvidence(string? ProfileId, string? ProfileVersion, string? ProfileHash)
+ {
+  public static GovernancePolicyEvidence Empty { get; } = new(null, null, null);
+  public bool IsEmpty => string.IsNullOrWhiteSpace(ProfileId) && string.IsNullOrWhiteSpace(ProfileVersion) && string.IsNullOrWhiteSpace(ProfileHash);
  }
 }

--- a/LoggingStandards/Services/ScoringEventTransformer.cs
+++ b/LoggingStandards/Services/ScoringEventTransformer.cs
@@ -73,7 +73,7 @@ public static class ScoringEventTransformer
             };
         }
 
-        return new ScoringEventDto
+        var dto = new ScoringEventDto
         {
             SchemaVersion = ContractVersions.ScoringEventSchemaVersion,
             TenantId = tenantId,
@@ -104,6 +104,14 @@ public static class ScoringEventTransformer
             InstanceId = EnvironmentDetector.InstanceId,
             DeploymentId = System.Environment.GetEnvironmentVariable("DEPLOYMENT_ID")
         };
+
+        SetPropertyIfExists(dto, "GovernanceProfileId", ExtractString(data, "GovernanceProfileId"));
+        SetPropertyIfExists(dto, "GovernanceProfileVersion", ExtractString(data, "GovernanceProfileVersion"));
+        SetPropertyIfExists(dto, "GovernanceProfileHash", ExtractString(data, "GovernanceProfileHash") ?? governanceAdapter?.GetPolicyEvidence().ProfileHash);
+        SetPropertyIfExists(dto, "GovernanceDecision", ExtractString(data, "GovernanceDecision"));
+        SetPropertyIfExists(dto, "EnforcementAction", ExtractString(data, "EnforcementAction"));
+
+        return dto;
     }
 
     /// <summary>
@@ -212,6 +220,16 @@ public static class ScoringEventTransformer
         }
 
         return result;
+    }
+
+    private static void SetPropertyIfExists(object target, string propertyName, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return;
+
+        var property = target.GetType().GetProperty(propertyName);
+        if (property?.CanWrite == true && property.PropertyType == typeof(string))
+            property.SetValue(target, value);
     }
 
     private static string? ExtractString(IDictionary<string, object> data, string key)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -190,3 +190,26 @@ Customize this file to add your own rules. Changes are hot-reloaded automaticall
 ---
 
 **Questions?** Check [TROUBLESHOOTING.md](TROUBLESHOOTING.md) or open an issue.
+
+## Governance evidence metadata
+
+When CerbiStream runtime governance is enabled, governed scoring events now carry lightweight evidence metadata alongside existing violation and governance mode fields. The runtime stamps these fields locally after policy validation and redaction; it does not call the control plane or perform remote governance lookup on the logging hot path.
+
+Emitted evidence fields include:
+
+- `GovernanceProfileId` when the active profile id/name can be resolved from `cerbi_governance.json`.
+- `GovernanceProfileVersion` when the active profile or root governance config declares a version.
+- `GovernanceProfileHash`, a stable SHA-256 hash of the canonical active profile JSON. If no active profile can be extracted, CerbiStream hashes the full governance config JSON instead.
+- `GovernanceDecision`:
+  - `allowed` when no violations are present and the event is not relaxed.
+  - `warned` when violations are present but no redaction or blocking action occurred.
+  - `redacted` when one or more policy-governed fields were redacted.
+  - `relaxed` when `GovernanceRelaxed` is true.
+  - `blocked` is reserved for an existing block mode and is not introduced by this runtime update.
+- `EnforcementAction`:
+  - `none` for allowed events.
+  - `warn` for warned events.
+  - `redact` for redacted events.
+  - `allow` for relaxed events, documenting that relaxed mode bypassed enforcement without dropping application flow.
+
+If the governance config is missing or malformed, CerbiStream keeps emitting the scoring event and omits evidence fields it cannot compute. No new required configuration fields are introduced.


### PR DESCRIPTION
### Motivation
- Surface lightweight, verifiable evidence about which governance profile and decision produced redaction/flags so downstream systems can audit and correlate events.
- Compute a stable policy fingerprint (SHA-256) of the active profile to support reproducible evidence without adding network lookups on the hot path.
- Preserve backward compatibility and runtime resilience when the governance config is missing or cannot be parsed.

### Description
- Updated package references to include `CerbiShield.Contracts` `1.2.0-preview.1` in `LoggingStandards/CerbiStream.csproj` to support new v1.2 DTO fields.
- Added `GovernancePolicyEvidence` and `GetPolicyEvidence()` to `GovernanceRuntimeAdapter`, implemented canonical active-profile JSON canonicalization and stable SHA-256 hashing with full-config fallback, and cached results for performance.
- Stamped runtime payloads during validation with `GovernanceProfileId`, `GovernanceProfileVersion`, `GovernanceProfileHash`, `GovernanceDecision`, and `EnforcementAction`, and implemented decision mapping (`relaxed`->`allow`, `redacted`->`redact`, `warned`->`warn`, `allowed`->`none`) while retaining existing blocking semantics.
- Updated `ScoringEventTransformer` to populate new v1.2 evidence fields when present on the log entry or available via `GovernanceRuntimeAdapter`, using a reflective helper `SetPropertyIfExists` so older DTO shapes remain compatible, and added docs in `docs/QUICKSTART.md` describing evidence metadata.
- Added focused unit tests to `CerbiStream--UnitTests` covering allowed/no-violation, forbidden-field redaction, relaxed mode, missing config resilience, and stable-hash behavior, plus transformer evidence propagation tests.

### Testing
- Added xUnit tests (new tests in `CerbiStream--UnitTests/GovernanceRuntimeAdapterTests.cs` and `CerbiStream--UnitTests/ScoringEventTransformerTests.cs`), but they were not executed in this environment.
- Ran `git diff --check` which produced no whitespace errors and changes were committed successfully.
- Attempted `dotnet build LoggingStandards/CerbiStream.csproj -f net9.0` but the build could not be run here because `dotnet` is not installed in the execution environment; CI should run the full test matrix to validate the new tests and ensure no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4aeb906358832d9e2da1548de2fd4a)

## Summary by Sourcery

Emit governance evidence metadata on governed scoring events, including stable policy fingerprints and decision/action fields, and wire this through CerbiStream runtime, transformers, docs, and tests while preserving resilience when governance config is absent or malformed.

New Features:
- Emit governance evidence metadata (profile id, version, hash, decision, enforcement action) on CerbiStream scoring events based on runtime governance configuration.

Enhancements:
- Compute and cache a stable SHA-256 fingerprint of the active governance profile (with full-config fallback) via canonical JSON hashing in GovernanceRuntimeAdapter.
- Extend ScoringEventTransformer to populate new v1.2 governance evidence fields on ScoringEventDto while remaining compatible with older DTO shapes.
- Document the new governance evidence metadata behavior and field semantics in QUICKSTART.md.

Build:
- Update CerbiStream project references to support CerbiShield.Contracts v1.2.0-preview.1 DTO fields.

Tests:
- Add unit tests for governance decision stamping, relaxed mode behavior, policy evidence hashing and missing-config resilience in GovernanceRuntimeAdapter.
- Add unit tests verifying evidence metadata propagation into scoring events and robustness when the governance adapter is missing or config is unavailable.