### PR TITLE
Update CerbiShield.Contracts to 1.3.1

### DIFF
--- a/LoggingStandards/CerbiStream.csproj
+++ b/LoggingStandards/CerbiStream.csproj
@@ -53,7 +53,7 @@
       <Aliases>GovernanceCore</Aliases>
     </PackageReference>
     <PackageReference Include="Cerbi.Governance.Runtime" Version="1.1.7" />
-    <PackageReference Include="CerbiShield.Contracts" Version="1.2.0-preview.1" />
+    <PackageReference Include="CerbiShield.Contracts" Version="1.3.1" />
     <PackageReference Include="Datadog.Trace" Version="3.25.0" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="4.4.0" />
     <PackageReference Include="Google.Cloud.PubSub.V1" Version="3.27.0" />


### PR DESCRIPTION
### Motivation
- Bring CerbiStream onto the stable `CerbiShield.Contracts` package to consume the finalized evidence metadata fields introduced after the preview, avoiding reliance on a preview package.
- Prevent mismatches between runtime evidence metadata and the published contracts while keeping downstream behavior (governance stamping/redaction) stable.

### Description
- Updated `LoggingStandards/CerbiStream.csproj` to change the package reference from `CerbiShield.Contracts` `1.2.0-preview.1` to `1.3.1`.
- Committed the project file change and verified there are no remaining references to `1.2.0-preview.1` in the repository.

### Testing
- Ran `dotnet restore` which completed successfully for the solution. 
- Built `LoggingStandards/CerbiStream.csproj` for `net8.0`, `net9.0`, and `net10.0` and all builds succeeded (warnings only). 
- Ran unit tests `dotnet test CerbiStream--UnitTests/UnitTests.csproj` for `net8.0`, `net9.0`, and `net10.0` and all test runs passed (148 passed, 2 skipped, 0 failed) including the evidence metadata tests for `GovernanceDecision` values and stable hash behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b251c619c832da17ed6164e828588)

## Summary by Sourcery

Build:
- Bump CerbiShield.Contracts package reference in LoggingStandards/CerbiStream.csproj from 1.2.0-preview.1 to 1.3.1.